### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-recommendations-ai",
     "distribution_name": "google-cloud-recommendations-ai",
     "api_id": "recommendationengine.googleapis.com",
-    "default_version": "",
+    "default_version": "v1beta1",
     "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,15 @@
 {
-  "name": "recommendationengine",
-  "name_pretty": "Recommendations AI",
-  "product_documentation": "https://cloud.google.com/recommendations-ai/",
-  "client_documentation": "https://googleapis.dev/python/recommendationengine/latest",
-  "issue_tracker": "",
-  "release_level": "beta",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-recommendations-ai",
-  "distribution_name": "google-cloud-recommendations-ai",
-  "api_id": "recommendationengine.googleapis.com"
+    "name": "recommendationengine",
+    "name_pretty": "Recommendations AI",
+    "product_documentation": "https://cloud.google.com/recommendations-ai/",
+    "client_documentation": "https://googleapis.dev/python/recommendationengine/latest",
+    "issue_tracker": "",
+    "release_level": "beta",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-recommendations-ai",
+    "distribution_name": "google-cloud-recommendations-ai",
+    "api_id": "recommendationengine.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114