### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "recommendationengine",
     "name_pretty": "Recommendations AI",
     "product_documentation": "https://cloud.google.com/recommendations-ai/",
-    "client_documentation": "https://googleapis.dev/python/recommendationengine/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/recommendationengine/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Recommendations AI
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-recommendations-ai.svg
    :target: https://pypi.org/project/google-cloud-recommendations-ai/
 .. _Cloud Recommendations AI API: https://cloud.google.com/recommendations-ai
-.. _Client Library Documentation: https://googleapis.dev/python/recommendationengine/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/recommendationengine/latest
 .. _Product Documentation:  https://cloud.google.com/recommendations-ai
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.