### PR TITLE
chore: update owlbot for mono repo migration

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -38,12 +38,6 @@ for library in s.get_staging_dirs(default_version):
         clean_up_generated_samples = False
     s.move([library], excludes=["**/gapic_version.py"])
 
-
-    s.replace(
-        library / "google/**/import_.py",
-        "gs://bucket/directory/\*\.json",
-        "``gs://bucket/directory/*.json``",
-    )
 s.remove_staging_dirs()
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Remove obsolete replacements in `owlbot.py`

Part of the work for https://github.com/googleapis/google-cloud-python/issues/10933
